### PR TITLE
Revert "Bump fs-file-tree from 1.1.2 to 2.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "dotenv": "^16.0.3",
                 "eleventy-plugin-gen-favicons": "^1.1.2",
                 "eleventy-plugin-nesting-toc": "^1.3.0",
-                "fs-file-tree": "^2.0.0",
+                "fs-file-tree": "^1.1.1",
                 "glob": "^10.2.1",
                 "gray-matter": "^4.0.3",
                 "jsep": "^1.4.0",
@@ -1639,6 +1639,15 @@
                 "node": ">=12"
             }
         },
+        "node_modules/assured": {
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/assured/-/assured-1.0.15.tgz",
+            "integrity": "sha512-EVb4T+6m5VdlTJ6gbv4WjBM1rHfzXP2BspsQ6VLswcnIQSabjJy7A9YEuG4/KmfF+9OEuT5xhqVJ+V1tClD5ww==",
+            "dependencies": {
+                "noop6": "^1.0.1",
+                "sliced": "^1.0.1"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1730,10 +1739,9 @@
             }
         },
         "node_modules/bindy": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/bindy/-/bindy-1.0.15.tgz",
-            "integrity": "sha512-UHnR/BIB6aGQXGb/RLuCBdyP9+N9XjLWa6I080UGsaISf6jXZoMDpQ/g5GOWXxVVKssyuhx0cdprlf6dlCt27g==",
-            "license": "MIT",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/bindy/-/bindy-1.0.14.tgz",
+            "integrity": "sha512-sf8QQyUicGz5QVUn7eHw9QJhzQHyHaY0HhwDdXiSg095gp0zkvADCZ8Yf3F12MtPsj3XZUX4joXMh4iaTApDVA==",
             "dependencies": {
                 "deffy": "^2.2.2",
                 "sliced": "^1.0.1"
@@ -1814,13 +1822,12 @@
             }
         },
         "node_modules/camelo": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/camelo/-/camelo-2.0.0.tgz",
-            "integrity": "sha512-fbEnC5FHYnU4YISuhVAYnqVxLTObpxWT4jhw745ESoSCdrZtZco/5b6NkYMum286s9ojFV5VXQivCPix86jw/A==",
-            "license": "MIT",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelo/-/camelo-1.2.1.tgz",
+            "integrity": "sha512-5O6lYuw6JR8viGfxFQhJTaO7cPTsnEaJUK2Gj0JeZ0O+iO78kxfeF47ocx6Ml0K8KWbE/JgBbgi3zF6lcUkvGw==",
             "dependencies": {
-                "regex-escape": "^4.0.0",
-                "uc-first-array": "^2.0.0"
+                "regex-escape": "^3.4.10",
+                "uc-first-array": "^1.1.10"
             }
         },
         "node_modules/chai": {
@@ -2084,10 +2091,9 @@
             }
         },
         "node_modules/deffy": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.5.tgz",
-            "integrity": "sha512-6TX2cfIo97eKqWmqgMDAUulCwnveAe3K+4VGsTGPJsL3NtSEnSBFZ3sUXdS4EBhZ8GbdaZBzXQ04ton18dJrug==",
-            "license": "MIT",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.4.tgz",
+            "integrity": "sha512-pLc9lsbsWjr6RxmJ2OLyvm+9l4j1yK69h+TML/gUit/t3vTijpkNGh8LioaJYTGO7F25m6HZndADcUOo2PsiUg==",
             "dependencies": {
                 "typpy": "^2.0.0"
             }
@@ -2799,13 +2805,16 @@
             }
         },
         "node_modules/fs-file-tree": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fs-file-tree/-/fs-file-tree-2.0.0.tgz",
-            "integrity": "sha512-Aryvb9HUZAkQmJavlKJ28KqNXfxK21eYvoprD7C+mdAlmnaNJpZxF3U380D7+Ktirf//GalKGqltqCp9G7w64A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fs-file-tree/-/fs-file-tree-1.1.2.tgz",
+            "integrity": "sha512-NCMV5VarvMM+NFNXBL5pOZLxHlyGI2Jt/DqKP9An1DqRrYGdcGUHcF9CnOw3QlAMP7F/TydHV+KwbY6rrG2Jvw==",
             "license": "MIT",
             "dependencies": {
-                "camelo": "^2.0.0",
-                "read-dir-and-stat": "^2.0.0"
+                "assured": "^1.0.14",
+                "bindy": "^1.0.3",
+                "camelo": "^1.1.3",
+                "read-dir-and-stat": "^1.0.0",
+                "same-time": "^2.3.1"
             }
         },
         "node_modules/fs.realpath": {
@@ -2836,10 +2845,9 @@
             }
         },
         "node_modules/function.name": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.14.tgz",
-            "integrity": "sha512-s99L814NRuLxwF2sJMIcLhkQhueGXb3oKyvorzrUKKwlVB0SBbWrgZt4+EwKAo3ujCXnT7vshmCvXgZA09kCMw==",
-            "license": "MIT",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.13.tgz",
+            "integrity": "sha512-mVrqdoy5npWZyoXl4DxCeuVF6delDcQjVS9aPdvLYlBxtMTZDR2B5GVEQEoM1jJyspCqg3C0v4ABkLE7tp9xFA==",
             "dependencies": {
                 "noop6": "^1.0.1"
             }
@@ -4490,10 +4498,9 @@
             }
         },
         "node_modules/noop6": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.10.tgz",
-            "integrity": "sha512-WZvuCILZFZHK+WuqCQwxLBGllkBK1ct8s8Mu9FMDbEsBE6/bqNxyFGbX7Xky+6bYFL8X2Ou4Cis4CJyrwXLvQA==",
-            "license": "MIT"
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.9.tgz",
+            "integrity": "sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA=="
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -5272,10 +5279,9 @@
             }
         },
         "node_modules/read-dir-and-stat": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-dir-and-stat/-/read-dir-and-stat-2.0.0.tgz",
-            "integrity": "sha512-r0P3JucZbQo+k/2yxcyBdJj74QmCzex5t4N3ogmHM3b3mEHh8i8LbRY8aeCOhwII5fxOuLVwWAzsDqBnQRJj4Q==",
-            "license": "MIT",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/read-dir-and-stat/-/read-dir-and-stat-1.0.8.tgz",
+            "integrity": "sha512-0iutmJymQddW2MTdPQdQPC+g6HlFGx6EwKd1P1VewhBYnJK8On7PQEkblm0XsVDECPBKn63pdyaBIS/COtFg0Q==",
             "dependencies": {
                 "bindy": "^1.0.3",
                 "same-time": "^2.3.1"
@@ -5307,10 +5313,9 @@
             }
         },
         "node_modules/regex-escape": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/regex-escape/-/regex-escape-4.0.0.tgz",
-            "integrity": "sha512-l2Hrkp0bUscGt27/q08lwG8XGmX1mjNGrpMvO4swSEcXAU/MAtn3PoPrx3i57Lot7tukVRiKuUB2m5kkI20bjQ==",
-            "license": "MIT"
+            "version": "3.4.10",
+            "resolved": "https://registry.npmjs.org/regex-escape/-/regex-escape-3.4.10.tgz",
+            "integrity": "sha512-qEqf7uzW+iYcKNLMDFnMkghhQBnGdivT6KqVQyKsyjSWnoFyooXVnxrw9dtv3AFLnD6VBGXxtZGAQNFGFTnCqA=="
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.2",
@@ -5482,10 +5487,9 @@
             }
         },
         "node_modules/same-time": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/same-time/-/same-time-2.3.6.tgz",
-            "integrity": "sha512-dlIuVqhVICrPUBd1raO5h9CYJgSCgrka6MT/os62Tdf4AqMHT0LzPhl92aBg7Np86H2zxMEyXy/3eGKlarioNA==",
-            "license": "MIT",
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/same-time/-/same-time-2.3.5.tgz",
+            "integrity": "sha512-SnVw4CihgrwwcZs38vqW1890OwilOQPnath+kQCX7Un+PfcjR52rThxPfuNpNEd3UrphL22/SleM7hcbiaJu1A==",
             "dependencies": {
                 "deffy": "2.0.0"
             }
@@ -5494,7 +5498,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.0.0.tgz",
             "integrity": "sha512-Gcn10MX982lqx8XmJES2JvN8Im7h0lFwRanyQfkQG2wXko4SouD0pSGUlK6Do165Itfidhpssn6NqlRkKp/4ig==",
-            "license": "KINDLY",
             "dependencies": {
                 "typpy": "^2.0.0"
             }
@@ -5757,9 +5760,7 @@
         "node_modules/sliced": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-            "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
-            "deprecated": "Unsupported",
-            "license": "MIT"
+            "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
         },
         "node_modules/slick": {
             "version": "1.12.2",
@@ -6271,25 +6272,31 @@
             }
         },
         "node_modules/typpy": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.4.0.tgz",
-            "integrity": "sha512-a16Uv5doNtvHzaG4wZCHmXN+l9xxmTMpyODtPz7B3DSTsDVNXilTSJGuNw68sUh0Un4bf+ghRMbEcJCI6r06mQ==",
-            "license": "MIT",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.13.tgz",
+            "integrity": "sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==",
             "dependencies": {
                 "function.name": "^1.0.3"
             }
         },
         "node_modules/uc-first-array": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/uc-first-array/-/uc-first-array-2.0.0.tgz",
-            "integrity": "sha512-ft1rZqwd2MNccWioUg+1JjC+Sn6A3bd0rZYX6QABHQvHgf2GZfWZNr4U3pTZYjgGMB31Ma8UnHt7Y6gPTUms3A==",
-            "license": "MIT"
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/uc-first-array/-/uc-first-array-1.1.10.tgz",
+            "integrity": "sha512-tX2PJLrqtexTxVN9hTTY+K5gPnF2gyj7SfjPF4Q2Xhbi1fSNiO12I/G+AoMzxJLwr9R50CmVn8iAhWCvZlJm3A==",
+            "dependencies": {
+                "ucfirst": "^1.0.0"
+            }
         },
         "node_modules/uc.micro": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "license": "MIT"
+        },
+        "node_modules/ucfirst": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ucfirst/-/ucfirst-1.0.0.tgz",
+            "integrity": "sha512-xbB/CQ0GdkxqH4IElZqenn/dL/tnyx7DCDASWJPE92ePbFM21kKemXI2LBeYtEvblf1Ol98hyJJS43Wu5JMQSQ=="
         },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "dotenv": "^16.0.3",
         "eleventy-plugin-gen-favicons": "^1.1.2",
         "eleventy-plugin-nesting-toc": "^1.3.0",
-        "fs-file-tree": "^2.0.0",
+        "fs-file-tree": "^1.1.1",
         "glob": "^10.2.1",
         "gray-matter": "^4.0.3",
         "jsep": "^1.4.0",


### PR DESCRIPTION
Reverts foxblock/foxblock.github.io#82

This still breaks a lot of stuff, because styles in the user folder are no longer properly added (probably because files are not discovered)